### PR TITLE
Add delete functionality for todo items

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -97,6 +97,67 @@ describe('App', () => {
     expect(checkbox).not.toBeChecked();
   });
 
+  it('deletes a todo when Delete button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Add two todos
+    const input = screen.getByPlaceholderText('Enter a todo...');
+    await user.type(input, 'First task{Enter}');
+    await user.type(input, 'Second task{Enter}');
+
+    // Verify both todos exist
+    expect(screen.getByText('First task')).toBeInTheDocument();
+    expect(screen.getByText('Second task')).toBeInTheDocument();
+
+    // Click Delete on first todo
+    const deleteButtons = screen.getAllByText('Delete');
+    await user.click(deleteButtons[0]);
+
+    // First todo should be removed
+    expect(screen.queryByText('First task')).not.toBeInTheDocument();
+    // Second todo should still exist
+    expect(screen.getByText('Second task')).toBeInTheDocument();
+  });
+
+  it('deletes all todos and shows empty state', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Add a todo
+    await user.type(screen.getByPlaceholderText('Enter a todo...'), 'Only task{Enter}');
+    expect(screen.getByText('Only task')).toBeInTheDocument();
+
+    // Delete it
+    await user.click(screen.getByText('Delete'));
+
+    // Should show empty state
+    expect(screen.queryByText('Only task')).not.toBeInTheDocument();
+    expect(screen.getByText(/No todos yet/i)).toBeInTheDocument();
+  });
+
+  it('persists deletion to localStorage', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<App />);
+
+    // Add two todos
+    const input = screen.getByPlaceholderText('Enter a todo...');
+    await user.type(input, 'Task A{Enter}');
+    await user.type(input, 'Task B{Enter}');
+
+    // Delete first todo
+    const deleteButtons = screen.getAllByText('Delete');
+    await user.click(deleteButtons[0]);
+
+    // Unmount and remount to simulate page reload
+    unmount();
+    render(<App />);
+
+    // Only Task B should exist after reload
+    expect(screen.queryByText('Task A')).not.toBeInTheDocument();
+    expect(screen.getByText('Task B')).toBeInTheDocument();
+  });
+
   it('persists todos to localStorage', async () => {
     const user = userEvent.setup();
     const { unmount } = render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,10 @@ function App() {
     );
   };
 
+  const handleDelete = (id: string) => {
+    setTodos(todos.filter((todo) => todo.id !== id));
+  };
+
   return (
     <div style={{ padding: '20px', maxWidth: '600px', margin: '0 auto' }}>
       <h1>To-Do List</h1>
@@ -67,6 +71,9 @@ function App() {
               marginBottom: '8px',
               border: '1px solid #ccc',
               borderRadius: '4px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
             }}
           >
             <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
@@ -84,6 +91,7 @@ function App() {
                 {todo.text}
               </span>
             </label>
+            <button onClick={() => handleDelete(todo.id)}>Delete</button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
Adds the ability to delete todo items from the list.

## Changes
- Add `handleDelete` function to filter out todos by ID
- Add Delete button to each todo item in the UI
- Minimal layout changes (flexbox to position delete button)
- No styling or animations added

## Implementation Details
- Delete button triggers `handleDelete(id)` which filters the todo array
- Existing `useEffect` automatically persists changes to localStorage
- No additional localStorage logic needed

## Tests Added
✅ Test deletion removes item from list
✅ Test deleting all items shows empty state
✅ Test deletion persists across page reload

## Verification
- ✅ All tests pass (20/20)
- ✅ Build succeeds
- ✅ Lint clean
- ✅ No new dependencies

## Screenshots
N/A - Minimal UI change (Delete button added)

---

**Note**: This PR should be reviewed before merging. Do not auto-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete buttons now available on each todo item in the list.
  * Deleted todos persist automatically, maintaining your changes across browser sessions and page reloads.
  * Empty state message displays when no todos remain, showing "No todos yet" for a clean slate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->